### PR TITLE
INSTALL.md: Clarify requirements for namespaced installs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,9 @@ HELM_CHART=custom-pod-autoscaler-operator
 helm install --set mode=namespaced --namespace=${NAMESPACE}  ${HELM_CHART} https://github.com/jthomperoo/custom-pod-autoscaler-operator/releases/download/${VERSION}/custom-pod-autoscaler-operator-${VERSION}.tgz
 ```
 
+Note that for a namespaced install to function correctly, a cluster-scoped
+install must be also present (installed into the `default` namespace).
+
 ## Kubectl
 
 ### Cluster scoped install
@@ -51,3 +54,6 @@ VERSION=v1.2.0
 kubectl config set-context --current --namespace=${NAMESPACE}
 kubectl apply -f https://github.com/jthomperoo/custom-pod-autoscaler-operator/releases/download/${VERSION}/namespaced.yaml
 ```
+
+Note that for a namespaced install to function correctly, a cluster-scoped
+install must be also present (installed into the `default` namespace).


### PR DESCRIPTION
Hi!

We twice (on different K8s clusters) ran into the same issue with a Helm-based, namespaced Operator install where the CPA CRD would never create the autoscaler Pod, and nothing useful would be logged.  After some trial and error, we discovered that we also needed to install the Operator into the `default` namespace, together with the namespaced install.  Once both installs were in place, the autoscaler Pod magically appeared and started doing its nice work.

Making this small PR so others don't run into the same issue.  Or, if you have any suggestions, please advise!

Thank you for the amazing project!  It's the least we can give back! :)